### PR TITLE
Add Groq AI proxy endpoint for chat generation

### DIFF
--- a/chatbot_backend/app.py
+++ b/chatbot_backend/app.py
@@ -217,6 +217,48 @@ def chat():
         return jsonify({'error': 'An internal error occurred.'}), 500
 
 
+@app.route('/api/generate', methods=['POST'])
+def generate():
+    # Public AI proxy: accepts { messages: Message[], mood?: string } and returns { reply }
+    if not groq:
+        return jsonify({"error": "Groq AI client is not configured on the server."}), 500
+
+    try:
+        data = request.get_json(silent=True) or {}
+        incoming_messages = data.get('messages') or []
+        mood = (data.get('mood') or 'neutral').strip().lower()
+
+        # Ensure messages are a list of { role, content }
+        safe_messages = []
+        for m in incoming_messages[-10:]:  # limit context
+            role = str(m.get('role', '')).strip().lower()
+            content = str(m.get('content', '')).strip()
+            if role in ('user', 'assistant') and content:
+                safe_messages.append({ 'role': role, 'content': content })
+
+        system_prompt = (
+            f"You are SoulScribe, an empathetic AI companion. The current mood is '{mood}'. "
+            f"Be concise, supportive, and practical. Avoid medical claims."
+        )
+
+        llm_messages = [{ 'role': 'system', 'content': system_prompt }] + safe_messages
+
+        completion = groq.chat.completions.create(
+            model='llama3-8b-8192',
+            messages=llm_messages,
+        )
+
+        reply = (completion.choices[0].message.content if completion and completion.choices else '').strip()
+        if not reply:
+            return jsonify({ 'error': 'No reply generated' }), 500
+
+        return jsonify({ 'reply': reply }), 200
+
+    except Exception as e:
+        # Return raw-ish error for easier debugging, mirroring the described behavior
+        return jsonify({ 'error': str(e) }), 500
+
+
 # --- Server Start ---
 if __name__ == '__main__':
     with app.app_context():

--- a/frontend/src/components/ChatView.js
+++ b/frontend/src/components/ChatView.js
@@ -54,13 +54,15 @@ function ChatView({ showAlert }) {
         // fall back to the backend REST API if available.
         console.warn('Supabase function invoke failed, attempting REST fallback:', fnErr.message || fnErr);
 
-        const apiBase = process.env.REACT_APP_API_BASE_URL || '';
-        if (!apiBase) throw fnErr;
+        // Fallback to local AI proxy implemented in Flask: /api/generate
+        const history = [...messages, { role: 'user', content: userMessage }]
+          .filter(m => m && (m.role === 'user' || m.role === 'assistant') && typeof m.content === 'string')
+          .slice(-10);
 
-        const resp = await fetch(`${apiBase.replace(/\/$/, '')}/chat`, {
+        const resp = await fetch('/api/generate', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ message: userMessage, mood: lastMood }),
+          body: JSON.stringify({ messages: history, mood: lastMood }),
         });
 
         if (!resp.ok) {
@@ -70,8 +72,7 @@ function ChatView({ showAlert }) {
         }
 
         const json = await resp.json();
-        // Expecting { reply: '...' } shape from the REST API
-        setMessages((prevMessages) => [...prevMessages, { role: 'assistant', content: json.reply || json.data || 'No reply' }]);
+        setMessages((prevMessages) => [...prevMessages, { role: 'assistant', content: json.reply || 'No reply' }]);
       }
 
     } catch (error) {


### PR DESCRIPTION
## Purpose

The user wants to implement a similar AI proxy logic that was successfully used in another Netlify-hosted project. They aim to integrate Groq API functionality into their current backend (hosted on Render) to handle chat message generation with mood context, following the pattern of accepting POST requests with messages and mood parameters.

## Code changes

- **Backend (`chatbot_backend/app.py`)**: Added new `/api/generate` endpoint that accepts POST requests with `{ messages: Message[], mood?: string }` format, processes the last 10 messages for context, integrates with Groq AI using the llama3-8b-8192 model, and returns `{ reply }` responses
- **Frontend (`frontend/src/components/ChatView.js`)**: Updated chat fallback logic to use the new `/api/generate` endpoint instead of the previous `/chat` endpoint, modified request payload to match the new API format with message history and mood contextTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 14`

🔗 [Edit in Builder.io](https://builder.io/app/projects/5b0d9099e72b4bdd8f62b46d91400c23/spark-zone)

👀 [Preview Link](https://5b0d9099e72b4bdd8f62b46d91400c23-spark-zone.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>5b0d9099e72b4bdd8f62b46d91400c23</projectId>-->
<!--<branchName>spark-zone</branchName>-->